### PR TITLE
fix: rt-2612 persist tilesInView across meetings

### DIFF
--- a/packages/roomkit-react/src/Prebuilt/components/AppData/AppData.tsx
+++ b/packages/roomkit-react/src/Prebuilt/components/AppData/AppData.tsx
@@ -33,7 +33,7 @@ import { DEFAULT_TILES_IN_VIEW } from '../MoreSettings/constants';
 const initialAppData = {
   [APP_DATA.uiSettings]: {
     [UI_SETTINGS.isAudioOnly]: false,
-    [UI_SETTINGS.maxTileCount]: 9,
+    [UI_SETTINGS.maxTileCount]: DEFAULT_TILES_IN_VIEW.DESKTOP,
     [UI_SETTINGS.showStatsOnTiles]: false,
     [UI_SETTINGS.enableAmbientMusic]: false,
     [UI_SETTINGS.uiViewMode]: UI_MODE_GRID,
@@ -125,17 +125,12 @@ export const AppData = React.memo(() => {
     hmsActions.setAppData(APP_DATA.uiSettings, updatedSettings, true);
   }, [hmsActions, preferences]);
 
+  // mobile does not allow custom maxTileCount
   useEffect(() => {
-    hmsActions.setAppData(
-      APP_DATA.uiSettings,
-      {
-        [UI_SETTINGS.maxTileCount]: isMobile
-          ? DEFAULT_TILES_IN_VIEW.MWEB
-          : Number(elements?.video_tile_layout?.grid?.tiles_in_view) || DEFAULT_TILES_IN_VIEW.DESKTOP,
-      },
-      true,
-    );
-  }, [hmsActions, isMobile, elements?.video_tile_layout?.grid?.tiles_in_view]);
+    if (isMobile) {
+      hmsActions.setAppData(APP_DATA.uiSettings, { [UI_SETTINGS.maxTileCount]: DEFAULT_TILES_IN_VIEW.MWEB }, true);
+    }
+  }, [hmsActions, isMobile]);
 
   useEffect(() => {
     if (!preferences.subscribedNotifications) {


### PR DESCRIPTION
RT-2612

`maxTileCount` is already being saved to local storage. Problem appeared to be that app state is forcefully reset to defaults on every boot, but it looks like that should only be needed for mobile

A little hard to confirm it fully _works_ without having lots of participants in a vid call, but on opening a new tab and entering a video, my tiles in view setting is now loaded correctly
<img width="977" alt="image" src="https://github.com/user-attachments/assets/5d98dc51-90a7-405a-bebd-bf76173b8aa6" />
