### PR TITLE
fix: RT-2616 changed heart eyes to heart emoji in EmojiCard component

### DIFF
--- a/packages/roomkit-react/src/Prebuilt/components/Footer/EmojiCard.jsx
+++ b/packages/roomkit-react/src/Prebuilt/components/Footer/EmojiCard.jsx
@@ -5,7 +5,7 @@ import { styled } from '../../../Theme';
 // When changing emojis in the grid, keep in mind that the payload used in sendHLSTimedMetadata has a limit of 100 characters. Using bigger emoji Ids can cause the limit to be exceeded.
 const emojiReactionList = [
   [{ emojiId: '+1' }, { emojiId: '-1' }, { emojiId: 'wave' }, { emojiId: 'clap' }, { emojiId: 'fire' }],
-  [{ emojiId: 'tada' }, { emojiId: 'heart_eyes' }, { emojiId: 'joy' }, { emojiId: 'open_mouth' }, { emojiId: 'sob' }],
+  [{ emojiId: 'tada' }, { emojiId: 'heart' }, { emojiId: 'joy' }, { emojiId: 'open_mouth' }, { emojiId: 'sob' }],
 ];
 
 export const EmojiCard = ({ sendReaction }) => {


### PR DESCRIPTION
# Description
- [RT-2616](https://linear.app/civic-roundtable/issue/RT-2616/replace-with-emoji-in-video-meetings)
- Heart eyes are now heart in emoji reactions

<img width="777" alt="Screenshot 2025-04-04 at 12 54 39 AM" src="https://github.com/user-attachments/assets/586f0ebf-e701-45cb-8852-3d355a21b292" />
