### PR TITLE
fix: RT-2717 update DEFAULT_TILES_IN_VIEW to 16

### DIFF
--- a/packages/roomkit-react/src/Prebuilt/components/MoreSettings/constants.ts
+++ b/packages/roomkit-react/src/Prebuilt/components/MoreSettings/constants.ts
@@ -11,4 +11,4 @@ export const trackTypeOptions = [
   { label: 'video', value: 'video' },
 ];
 
-export const DEFAULT_TILES_IN_VIEW = { MWEB: 4, DESKTOP: 9 };
+export const DEFAULT_TILES_IN_VIEW = { MWEB: 4, DESKTOP: 16 };


### PR DESCRIPTION
[RT-2717](https://linear.app/civic-roundtable/issue/RT-2717/increase-default-number-of-tiles-shown-in-video-meetings-from-9-to-16)

Changed `DEFAULT_TILES_IN_VIEW` to 16